### PR TITLE
Feat/namdng09/create execises module

### DIFF
--- a/server/src/configs/db.ts
+++ b/server/src/configs/db.ts
@@ -6,8 +6,10 @@ const db = process.env.MONGO_URI as string;
 
 const connectDB = async () => {
   try {
-    await mongoose.connect(db);
-    console.log('MongoDB is Connected...');
+    const conn = await mongoose.connect(db);
+    const hostPort = `${conn.connection.host}:${conn.connection.port}`;
+    const dbName = conn.connection.name;
+    console.log(`MongoDB is Connected: ${hostPort}/${dbName}`);
   } catch (error) {
     console.error(error);
     process.exit(1);

--- a/server/src/modules/muscles/muscle-controller.ts
+++ b/server/src/modules/muscles/muscle-controller.ts
@@ -1,0 +1,48 @@
+import { Request, Response } from 'express';
+
+import ApiResponse from '~/types/api-response';
+
+import MuscleService from './muscle-service';
+
+const MuscleController = {
+  findAll: async (req: Request, res: Response) => {
+    const muscles = await MuscleService.findAll();
+
+    return muscles;
+  },
+
+  findById: async (req: Request, res: Response) => {
+    const muscleId = req.params.id;
+    const muscle = await MuscleService.findById(muscleId);
+    return res
+      .status(200)
+      .json(ApiResponse.success('Muscle retrieved successfully', muscle));
+  },
+
+  create: async (req: Request, res: Response) => {
+    const muscleData = req.body;
+    const newMuscle = await MuscleService.create(muscleData, req.file);
+    return res
+      .status(201)
+      .json(ApiResponse.success('Muscle created successfully', newMuscle));
+  },
+
+  update: async (req: Request, res: Response) => {
+    const muscleId = req.params.id;
+    const updateData = req.body;
+    const updatedMuscle = await MuscleService.update(muscleId, updateData);
+    return res
+      .status(200)
+      .json(ApiResponse.success('Muscle updated successfully', updatedMuscle));
+  },
+
+  remove: async (req: Request, res: Response) => {
+    const muscleId = req.params.id;
+    await MuscleService.remove(muscleId);
+    return res
+      .status(204)
+      .json(ApiResponse.success('Muscle deleted successfully', null));
+  }
+};
+
+export default MuscleController;

--- a/server/src/modules/muscles/muscle-controller.ts
+++ b/server/src/modules/muscles/muscle-controller.ts
@@ -46,8 +46,8 @@ const MuscleController = {
     const muscleId = req.params.id;
     await MuscleService.remove(muscleId);
     return res
-      .status(204)
-      .json(ApiResponse.success('Muscle deleted successfully', null));
+      .status(200)
+      .json(ApiResponse.success('Muscle deleted successfully'));
   }
 };
 

--- a/server/src/modules/muscles/muscle-controller.ts
+++ b/server/src/modules/muscles/muscle-controller.ts
@@ -8,7 +8,9 @@ const MuscleController = {
   findAll: async (req: Request, res: Response) => {
     const muscles = await MuscleService.findAll();
 
-    return muscles;
+    return res
+      .status(200)
+      .json(ApiResponse.success('Muscles retrieved successfully', muscles));
   },
 
   findById: async (req: Request, res: Response) => {

--- a/server/src/modules/muscles/muscle-controller.ts
+++ b/server/src/modules/muscles/muscle-controller.ts
@@ -32,7 +32,11 @@ const MuscleController = {
   update: async (req: Request, res: Response) => {
     const muscleId = req.params.id;
     const updateData = req.body;
-    const updatedMuscle = await MuscleService.update(muscleId, updateData);
+    const updatedMuscle = await MuscleService.update(
+      muscleId,
+      updateData,
+      req.file
+    );
     return res
       .status(200)
       .json(ApiResponse.success('Muscle updated successfully', updatedMuscle));

--- a/server/src/modules/muscles/muscle-route.ts
+++ b/server/src/modules/muscles/muscle-route.ts
@@ -8,7 +8,22 @@ import MuscleValidationSchema from './muscle-validation';
 
 const router: Router = express.Router();
 
-// Get a single food
+router.get('/', asyncHandler(MuscleController.findAll));
+
 router.get('/:id', asyncHandler(MuscleController.findById));
+
+router.post(
+  '/',
+  validate(MuscleValidationSchema.shape),
+  asyncHandler(MuscleController.create)
+);
+
+router.put(
+  '/',
+  validate(MuscleValidationSchema.shape),
+  asyncHandler(MuscleController.update)
+);
+
+router.delete('/:id', asyncHandler(MuscleController.remove));
 
 export default router;

--- a/server/src/modules/muscles/muscle-route.ts
+++ b/server/src/modules/muscles/muscle-route.ts
@@ -21,7 +21,7 @@ router.post(
 );
 
 router.put(
-  '/',
+  '/:id',
   uploadSingle('image'),
   validate(MuscleValidationSchema.shape),
   asyncHandler(MuscleController.update)

--- a/server/src/modules/muscles/muscle-route.ts
+++ b/server/src/modules/muscles/muscle-route.ts
@@ -2,6 +2,7 @@ import express, { Router } from 'express';
 
 import validate from '~/middleware/validate';
 import asyncHandler from '~/utils/async-handler';
+import { uploadSingle } from '~/utils/multer';
 
 import MuscleController from './muscle-controller';
 import MuscleValidationSchema from './muscle-validation';
@@ -15,12 +16,14 @@ router.get('/:id', asyncHandler(MuscleController.findById));
 router.post(
   '/',
   validate(MuscleValidationSchema.shape),
+  uploadSingle('image'),
   asyncHandler(MuscleController.create)
 );
 
 router.put(
   '/',
   validate(MuscleValidationSchema.shape),
+  uploadSingle('image'),
   asyncHandler(MuscleController.update)
 );
 

--- a/server/src/modules/muscles/muscle-route.ts
+++ b/server/src/modules/muscles/muscle-route.ts
@@ -15,15 +15,15 @@ router.get('/:id', asyncHandler(MuscleController.findById));
 
 router.post(
   '/',
-  validate(MuscleValidationSchema.shape),
   uploadSingle('image'),
+  validate(MuscleValidationSchema.shape),
   asyncHandler(MuscleController.create)
 );
 
 router.put(
   '/',
-  validate(MuscleValidationSchema.shape),
   uploadSingle('image'),
+  validate(MuscleValidationSchema.shape),
   asyncHandler(MuscleController.update)
 );
 

--- a/server/src/modules/muscles/muscle-route.ts
+++ b/server/src/modules/muscles/muscle-route.ts
@@ -1,0 +1,14 @@
+import express, { Router } from 'express';
+
+import validate from '~/middleware/validate';
+import asyncHandler from '~/utils/async-handler';
+
+import MuscleController from './muscle-controller';
+import MuscleValidationSchema from './muscle-validation';
+
+const router: Router = express.Router();
+
+// Get a single food
+router.get('/:id', asyncHandler(MuscleController.findById));
+
+export default router;

--- a/server/src/modules/muscles/muscle-service.ts
+++ b/server/src/modules/muscles/muscle-service.ts
@@ -1,0 +1,112 @@
+import createHttpError from 'http-errors';
+
+import MuscleModel from './muscle-model';
+import { IMuscle } from './muscle-type';
+import { uploadImage } from '~/utils/cloudinary';
+
+const MuscleService = {
+  findAll: async () => {
+    const muscles = await MuscleModel.find();
+
+    return muscles;
+  },
+
+  findById: async (muscleId: string) => {
+    const muscle = await MuscleModel.findById(muscleId);
+
+    if (!muscle) {
+      throw createHttpError(404, 'Muscle not found');
+    }
+  },
+
+  create: async (muscleData: IMuscle, file?: Express.Multer.File) => {
+    if (!file) {
+      throw createHttpError(400, 'No file provided');
+    }
+
+    const existingMuscle = await MuscleModel.findOne({
+      title: muscleData.title
+    });
+    if (existingMuscle) {
+      throw createHttpError(409, 'Muscle with this title already exists');
+    }
+
+    let imageUrl: string | undefined;
+    if (file) {
+      const uploadResult = await uploadImage(file.buffer);
+
+      if (!uploadResult.success || !uploadResult.data) {
+        throw createHttpError(
+          500,
+          uploadResult.error || 'Failed to upload image'
+        );
+      }
+
+      imageUrl = uploadResult.data.secure_url;
+    }
+
+    const newMuscleData = { ...muscleData, image: imageUrl };
+
+    const newMuscle = MuscleModel.create(newMuscleData);
+    if (!newMuscle) {
+      throw createHttpError(500, 'Failed to create muscle');
+    }
+
+    return newMuscle;
+  },
+
+  update: async (
+    muscleId: string,
+    updateData: Partial<IMuscle>,
+    file?: Express.Multer.File
+  ) => {
+    const existingMuscle = await MuscleModel.findById(muscleId);
+    if (!existingMuscle) {
+      throw createHttpError(404, 'Muscle not found');
+    }
+
+    let imageUrl: string | undefined;
+    if (file) {
+      const uploadResult = await uploadImage(file.buffer);
+
+      if (!uploadResult.success || !uploadResult.data) {
+        throw createHttpError(
+          500,
+          uploadResult.error || 'Failed to upload image'
+        );
+      }
+
+      imageUrl = uploadResult.data.secure_url;
+    }
+
+    const updatedMuscleData = {
+      ...updateData,
+      image: imageUrl || existingMuscle.image
+    };
+
+    const updatedMuscle = await MuscleModel.findByIdAndUpdate(
+      muscleId,
+      updatedMuscleData,
+      {
+        new: true,
+        runValidators: true
+      }
+    );
+
+    if (!updatedMuscle) {
+      throw createHttpError(500, 'Failed to update muscle');
+    }
+
+    return updatedMuscle;
+  },
+
+  remove: async (muscleId: string) => {
+    const muscle = await MuscleModel.findByIdAndDelete(muscleId);
+
+    if (!muscle) {
+      throw createHttpError(404, 'Muscle not found');
+    }
+  }
+};
+
+export default MuscleService;

--- a/server/src/modules/muscles/muscle-service.ts
+++ b/server/src/modules/muscles/muscle-service.ts
@@ -1,8 +1,10 @@
 import createHttpError from 'http-errors';
+import { Types } from 'mongoose';
+
+import { uploadImage } from '~/utils/cloudinary';
 
 import MuscleModel from './muscle-model';
 import { IMuscle } from './muscle-type';
-import { uploadImage } from '~/utils/cloudinary';
 
 const MuscleService = {
   findAll: async () => {
@@ -12,6 +14,10 @@ const MuscleService = {
   },
 
   findById: async (muscleId: string) => {
+    if (!Types.ObjectId.isValid(muscleId)) {
+      throw createHttpError(400, 'Invalid ObjectId');
+    }
+
     const muscle = await MuscleModel.findById(muscleId);
 
     if (!muscle) {
@@ -60,6 +66,10 @@ const MuscleService = {
     updateData: Partial<IMuscle>,
     file?: Express.Multer.File
   ) => {
+    if (!Types.ObjectId.isValid(muscleId)) {
+      throw createHttpError(400, 'Invalid ObjectId');
+    }
+
     const existingMuscle = await MuscleModel.findById(muscleId);
     if (!existingMuscle) {
       throw createHttpError(404, 'Muscle not found');
@@ -101,6 +111,10 @@ const MuscleService = {
   },
 
   remove: async (muscleId: string) => {
+    if (!Types.ObjectId.isValid(muscleId)) {
+      throw createHttpError(400, 'Invalid ObjectId');
+    }
+
     const muscle = await MuscleModel.findByIdAndDelete(muscleId);
 
     if (!muscle) {

--- a/server/src/modules/muscles/muscle-validation.ts
+++ b/server/src/modules/muscles/muscle-validation.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+const MuscleValidation = {
+  title: z.string(),
+  image: z.string(),
+};
+
+const MuscleValidationSchema = z.object(MuscleValidation);
+
+export default MuscleValidationSchema;

--- a/server/src/modules/muscles/muscle-validation.ts
+++ b/server/src/modules/muscles/muscle-validation.ts
@@ -1,8 +1,7 @@
 import { z } from 'zod';
 
 const MuscleValidation = {
-  title: z.string(),
-  image: z.string(),
+  title: z.string()
 };
 
 const MuscleValidationSchema = z.object(MuscleValidation);

--- a/server/src/routes/router.ts
+++ b/server/src/routes/router.ts
@@ -4,6 +4,7 @@ import authorize from '~/middleware/authorize';
 import AuthRoutes from '~/modules/auth/auth-route';
 import FoodRoute from '~/modules/foods/food-route';
 import UserRoute from '~/modules/users/user-route';
+import MuscleRouter from '~/modules/muscles/muscle-route';
 
 const router = Router();
 // Non-auth routes
@@ -14,5 +15,8 @@ router.use('/users', UserRoute);
 
 // Food routes
 router.use('/foods', FoodRoute);
+
+// Muscle routes
+router.use('/muscles', MuscleRouter);
 
 export default router;


### PR DESCRIPTION
This pull request introduces a new "muscles" module to the backend API, providing full CRUD (Create, Read, Update, Delete) functionality for muscle entities, including input validation and image upload support. It also improves MongoDB connection logging for better debugging.

**Muscles Module Implementation:**

* Added a new `muscle-controller.ts` with handlers for listing, retrieving, creating (with image upload), updating, and deleting muscles, all using a consistent API response format.
* Implemented `muscle-service.ts` with business logic for muscle operations, including validation of IDs, checking for duplicate titles, uploading images to Cloudinary, and robust error handling.
* Created `muscle-route.ts` to define RESTful routes for muscles, integrating middleware for validation, file upload, and async error handling.
* Added `muscle-validation.ts` using Zod to validate incoming muscle data (currently only the `title` field).
* Registered the new muscle routes in the main application router (`/muscles`). [[1]](diffhunk://#diff-eae5f2f1d7ddbeccaf61f6ee30010aff4c2274857af5e013d2cb89feaa4a862eR7) [[2]](diffhunk://#diff-eae5f2f1d7ddbeccaf61f6ee30010aff4c2274857af5e013d2cb89feaa4a862eR19-R21)

**Infrastructure Improvements:**

* Enhanced MongoDB connection logging to include the host, port, and database name for easier debugging and monitoring.